### PR TITLE
Add failsafe for when all entries of the board are deleted

### DIFF
--- a/cotn_twitter.py
+++ b/cotn_twitter.py
@@ -54,6 +54,8 @@ def update(twitter):
                 deletedEntries = board.checkForDeleted(90)
                 if deletedEntries > 0:
                     print("Found", deletedEntries, "deleted entries in", str(board))
+                if deletedEntries >= len(board.history):
+                    raise Exception('ERROR:', deletedEntries, 'all entries deleted')
                 if deletedEntries > 60:
                     raise Exception('ERROR:', deletedEntries, 'too many deleted entries')
                 entries = board.diffingEntries(twitter=twitter)


### PR DESCRIPTION
Full disclosure, I didn't test this before making this PR. But the idea is to raise an exception if the number of deleted entries is equal (or more?) than the number of entries, this is because seeded leaderboards have as low as 11 entries (Coda Seeded speed) right now, so it won't get caught by the 60 failsafe.
